### PR TITLE
Use unittest.mock instead of fudge.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 .installed.cfg
-.dir-locals.el
-.pydevproject
-.project
+
 *.egg-info
 *.pyc
 .coverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,14 @@
 =========
 
 
-2.0.2 (unreleased)
+2.1.0 (unreleased)
 ==================
 
 - Make ``Acquisition`` an optional dependency. If it is not installed,
   the ``aq_inContextOf`` matcher will always return False.
-
+- Remove dependency on ``fudge``. Instead, we now use ``unittest.mock`` on
+  Python 3, or its backport ``mock`` on Python 2. See `issue 11
+  <https://github.com/NextThought/nti.testing/issues/11>`_.
 
 2.0.1 (2017-10-18)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 from setuptools import setup, find_packages
 
 
-version = '2.0.2.dev0'
+version = '2.1.0.dev0'
 
 entry_points = {
 }
@@ -49,7 +49,6 @@ setup(
     namespace_packages=['nti'],
     install_requires=[
         'zope.interface >= 4.1.2', # Listing first to work around a Travis CI issue
-        'fudge',
         'pyhamcrest',
         'six',
         'setuptools',
@@ -67,6 +66,10 @@ setup(
         'docs': [
             'Sphinx',
             'sphinx_rtd_theme',
+        ],
+        ':python_version == "2.7"' : [
+            # backport of unittest.mock for Python 2.7.
+            'mock',
         ],
     },
 )


### PR DESCRIPTION
No user visible changes (unless they were relying on fudge as a transient dependency). 

Fixes #11.