### PR TITLE
Add support for zope.interface 5 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 language: python
-sudo: false
 python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
   - pypy
   - pypy3
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+env:
+    global:
+        - PYTHONHASHSEED=1042466059
 
 after_success:
   - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,13 @@
 =========
 
 
-2.2.2 (unreleased)
+3.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.8.
 
+- Require zope.interface 5.1. This lets the interface matchers produce
+  much more informative error messages.
 
 2.2.1 (2019-09-10)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ implements it::
    ...     got_that_thing_i_sent_you = Attribute("Did you get that thing?")
    >>> @implementer(IThings)
    ... class Thing(object):
-   ...     pass
+   ...     def __repr__(self): return "<object Thing>"
 
    >>> from nti.testing.matchers import provides, implements
    >>> assert_that(Thing(), provides(IThings))
@@ -91,15 +91,33 @@ where the next stricter check comes in. ``verifiably_provides`` uses
 the interface machinery to determine that all attributes and methods
 specified by the interface are present as described::
 
-
   >>> from nti.testing.matchers import verifiably_provides
   >>> assert_that(Thing(), verifiably_provides(IThing2, IThing1))
   >>> assert_that(Thing(), verifiably_provides(IThings))
   Traceback (most recent call last):
   ...
   AssertionError:...
-  Expected: object verifiably providing IThings
-       but: <class 'Thing'> failed to provide attribute "got_that_thing_i_sent_you" from IThings
+  Expected: object verifiably providing <InterfaceClass ...IThings>
+       but: Using class <class 'Thing'> the object <object Thing> has failed to implement interface <InterfaceClass ....IThings>: The ....IThings.got_that_thing_i_sent_you attribute was not provided.
+  <BLANKLINE>
+
+If multiple attributes or methods are not provided, all such missing
+information is reported::
+
+  >>> class IThingReceiver(IThings):
+  ...    def receive(some_thing):
+  ...        """Get the thing"""
+  >>> @implementer(IThingReceiver)
+  ... class ThingReceiver(object):
+  ...     def __repr__(self): return "<object ThingReceiver>"
+  >>> assert_that(ThingReceiver(), verifiably_provides(IThingReceiver))
+  Traceback (most recent call last):
+  ...
+  AssertionError:...
+  Expected: object verifiably providing <InterfaceClass ...IThingReceiver>
+       but: Using class <class 'ThingReceiver'> the object <object ThingReceiver> has failed to implement interface <InterfaceClass ....IThingReceiver>:
+            The ....IThings.got_that_thing_i_sent_you attribute was not provided
+            The ....IThingReceiver.receive(some_thing) attribute was not provided
   <BLANKLINE>
 
 ``zope.interface`` can only check whether or not an attribute or
@@ -112,7 +130,7 @@ values of the attributes, we can step up to ``zope.schema`` and the
   ...     got_that_thing_i_sent_you = Bool()
   >>> @implementer(IBoolThings)
   ... class BoolThing(object):
-  ...     pass
+  ...     def __repr__(self): return "<object BoolThing>"
 
 ``validly_provides`` is a superset of ``verifiably_provides``::
 
@@ -122,8 +140,8 @@ values of the attributes, we can step up to ``zope.schema`` and the
   Traceback (most recent call last):
   ...
   AssertionError:...
-  Expected: (object verifiably providing IBoolThings and object validly providing <InterfaceClass ....IBoolThings>)
-       but: object verifiably providing IBoolThings <class 'BoolThing'> failed to provide attribute "got_that_thing_i_sent_you" from IBoolThings
+  Expected: (object verifiably providing <InterfaceClass ...IBoolThings> and object validly providing <InterfaceClass ....IBoolThings>)
+       but: object verifiably providing <InterfaceClass ....IBoolThings> Using class <class 'BoolThing'> the object <object BoolThing> has failed to implement interface <InterfaceClass ....IBoolThings>: The ....IBoolThings.got_that_thing_i_sent_you attribute was not provided.
   <BLANKLINE>
 
 For finer grained control, we can compare data against schema fields::

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ TESTS_REQUIRE = [
     'Acquisition',
     'zope.site',
     'zope.testrunner',
+    'ZODB',
 ]
 
 def _read(fname):
@@ -29,6 +30,9 @@ setup(
     license='Apache',
     keywords='nose2 testing zope3 ZTK hamcrest',
     url='https://github.com/NextThought/nti.testing',
+    project_urls={
+        'Documentation': 'https://ntitesting.readthedocs.io/en/latest/',
+    },
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -39,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',
@@ -49,7 +54,7 @@ setup(
     package_dir={'': 'src'},
     namespace_packages=['nti'],
     install_requires=[
-        'zope.interface >= 4.1.2', # Listing first to work around a Travis CI issue
+        'zope.interface >= 5.1', # Error messages changed.
         'pyhamcrest',
         'six',
         'setuptools',

--- a/src/nti/testing/tests/test_matchers.py
+++ b/src/nti/testing/tests/test_matchers.py
@@ -91,18 +91,26 @@ class TestMatchers(unittest.TestCase):
                 raise AssertionError("Not called")
 
         assert_that(Thing(), matchers.verifiably_provides(IThing, IThing))
-        assert_that(calling(assert_that).with_args(self, matchers.verifiably_provides(IThing)),
-                    raises(AssertionError, "does not implement"))
+        # We have a nice multi-line error message, but we can only match one line at a time
+        for line in (
+                'verifiably providing .*IThing',
+                'Using class.*has failed to implement',
+                'Does not declaratively implement',
+                'thing attribute was not provided',
+                r'method\(\) attribute was not provided',
+        ):
+            assert_that(calling(assert_that).with_args(self, matchers.verifiably_provides(IThing)),
+                        raises(AssertionError, line))
 
         broken_thing = Thing()
         broken_thing.method = None
         assert_that(calling(assert_that).with_args(broken_thing,
                                                    matchers.verifiably_provides(IThing)),
-                    raises(AssertionError, "violates its contract"))
+                    raises(AssertionError, r"The contract of.*method\(\) is violated"))
 
         del Thing.thing
         assert_that(calling(assert_that).with_args(Thing(), matchers.verifiably_provides(IThing)),
-                    raises(AssertionError, "failed to provide attribute"))
+                    raises(AssertionError, "thing attribute was not provided"))
 
     def test_validly_provides(self):
 
@@ -117,8 +125,15 @@ class TestMatchers(unittest.TestCase):
             thing = 1
 
         assert_that(Thing(), matchers.validly_provides(IThing, IThing))
-        assert_that(calling(assert_that).with_args(self, matchers.validly_provides(IThing)),
-                    raises(AssertionError, "does not implement"))
+        # We have a nice multi-line error message, but we can only match one line at a time
+        for line in (
+                'verifiably providing .*IThing.*validly providing.*IThing',
+                'Using class.*has failed to implement',
+                'Does not declaratively implement',
+                'thing attribute was not provided'
+        ):
+            assert_that(calling(assert_that).with_args(self, matchers.validly_provides(IThing)),
+                        raises(AssertionError, line))
 
         broken_thing = Thing()
         broken_thing.thing = "not an int"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = pypy,py27,py35,py36,py37,pypy3,coverage,docs
+envlist = pypy,py27,py35,py36,py37,py38,pypy3,coverage,docs
 
 [testenv]
 deps =
      .[test]
 commands =
          zope-testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
+setenv =
+    PYTHONHASHSEED=1042466059
 
 [testenv:coverage]
 usedevelop = true


### PR DESCRIPTION
The former brings much improved error messages, which we were shadowing incorrectly. This broke our tests and was badly formatted.