### PR TITLE
Add a test that reproduces a ConnectionStateError on PyPy, and fix it.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 - Require zope.interface 5.1. This lets the interface matchers produce
   much more informative error messages.
 
+- Add ``nti.testing.zodb`` with helpers for dealing with ZODB.
+
 2.2.1 (2019-09-10)
 ==================
 

--- a/src/nti/testing/tests/test_layers.py
+++ b/src/nti/testing/tests/test_layers.py
@@ -33,32 +33,24 @@ class TestLayers(unittest.TestCase):
 
         via_test(self)
 
+    def _check_methods(self, layer, extra_methods=()):
+        default_methods = ('setUp', 'tearDown', 'testSetUp', 'testTearDown')
+        for meth in default_methods + extra_methods:
+            getattr(layer, meth)()
+
     def test_gc(self):
 
         gcm = layers.GCLayerMixin()
-
-        for meth in 'setUp', 'tearDown', 'testSetUp', 'testTearDown', 'setUpGC', 'tearDownGC':
-            getattr(gcm, meth)()
+        self._check_methods(gcm, ('setUpGC', 'tearDownGC'))
 
     def test_shared_cleanup(self):
-
-        gcm = layers.SharedCleanupLayer()
-
-        for meth in 'setUp', 'tearDown', 'testSetUp', 'testTearDown':
-            getattr(gcm, meth)()
+        self._check_methods(layers.SharedCleanupLayer)
 
     def test_zcl(self):
-
-        gcm = layers.ZopeComponentLayer()
-
-        for meth in 'setUp', 'tearDown', 'testSetUp', 'testTearDown':
-            getattr(gcm, meth)()
+        self._check_methods(layers.ZopeComponentLayer)
 
     def test_configuring_layer_mixin(self):
-
         class Layer(layers.ConfiguringLayerMixin):
             set_up_packages = ('zope.component',)
 
-        for meth in ('setUp', 'tearDown', 'testSetUp', 'testTearDown',
-                     'setUpPackages', 'tearDownPackages'):
-            getattr(Layer, meth)()
+        self._check_methods(Layer, ('setUpPackages', 'tearDownPackages'))


### PR DESCRIPTION
Original comment: https://github.com/NextThought/nti.dataserver-buildout/pull/1025#issuecomment-642876378
Pending PyPy fix in persistent: https://github.com/zopefoundation/persistent/issues/149